### PR TITLE
Ignore symlinks when formatting

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -9,6 +9,7 @@
 module Main where
 
 import Control.Concurrent (Chan, forkIO, newChan, readChan, writeChan)
+import Control.Exception (IOException, try)
 import Data.Bifunctor (first)
 import Data.Either (lefts)
 import Data.Text (Text)
@@ -17,6 +18,7 @@ import GHC.IO.Encoding (utf8)
 import Paths_nixfmt (version)
 import System.Console.CmdArgs
   (Data, Typeable, args, cmdArgs, help, summary, typ, (&=))
+import System.Directory (pathIsSymbolicLink)
 import System.Exit (ExitCode(..), exitFailure, exitSuccess)
 import System.IO (hPutStrLn, hSetEncoding, stderr)
 import System.Posix.Process (exitImmediately)
@@ -50,42 +52,44 @@ options = Nixfmt
 format' :: Width -> FilePath -> Text -> Either String Text
 format' w path = first errorBundlePretty . format w path
 
-data Target = Target
-    { tDoRead :: IO Text
-    , tPath :: FilePath
-    , tDoWrite :: Text -> IO ()
-    }
+data Target
+    = StdioTarget
+    | FileTarget FilePath
+
+targetName :: Target -> String
+targetName StdioTarget = "<stdin>"
+targetName (FileTarget path) = path
+
+readTarget :: Target -> IO Text
+readTarget StdioTarget = TextIO.getContents
+readTarget (FileTarget path) = readFileUtf8 path
+
+writeTarget :: Target -> Text -> IO ()
+writeTarget StdioTarget t = TextIO.putStr t
+writeTarget (FileTarget path) t = withOutputFile path $ \h -> do
+    hSetEncoding h utf8
+    TextIO.hPutStr h t
 
 formatTarget :: Width -> Target -> IO Result
-formatTarget w Target{tDoRead, tPath, tDoWrite} = do
-    contents <- tDoRead
-    let formatted = format' w tPath contents
-    mapM tDoWrite formatted
+formatTarget w target = do
+    contents <- readTarget target
+    let formatted = format' w (targetName target) contents
+    mapM (writeTarget target) formatted
 
 -- | Return an error if target could not be parsed or was not formatted
 -- correctly.
 checkTarget :: Width -> Target -> IO Result
-checkTarget w Target{tDoRead, tPath} = do
-    contents <- tDoRead
-    return $ case format' w tPath contents of
+checkTarget w target = do
+    contents <- readTarget target
+    return $ case format' w (targetName target) contents of
         Left err -> Left err
         Right formatted
             | formatted == contents -> Right ()
-            | otherwise             -> Left $ tPath ++ ": not formatted"
-
-stdioTarget :: Target
-stdioTarget = Target TextIO.getContents "<stdin>" TextIO.putStr
-
-fileTarget :: FilePath -> Target
-fileTarget path = Target (readFileUtf8 path) path atomicWriteFile
-  where
-    atomicWriteFile t = withOutputFile path $ \h -> do
-      hSetEncoding h utf8
-      TextIO.hPutStr h t
+            | otherwise             -> Left $ (targetName target) ++ ": not formatted"
 
 toTargets :: Nixfmt -> [Target]
-toTargets Nixfmt{ files = [] }    = [stdioTarget]
-toTargets Nixfmt{ files = paths } = map fileTarget paths
+toTargets Nixfmt{ files = [] }    = [StdioTarget]
+toTargets Nixfmt{ files = paths } = map FileTarget paths
 
 toOperation :: Nixfmt -> Target -> IO Result
 toOperation Nixfmt{ width = w, check = True } = checkTarget w


### PR DESCRIPTION
Before this, symlinks were replaced with a formatted file rather than
formatting the file behind the symlink. The choice was between ignoring
symlinks and following them. Following symlinks means potentially
formatting files in an unexpected location which seems much worse than
needing to wrap the arguments in a `readlink -f` when symlinks are
otherwise ignored.

Fixes #56.