### PR TITLE
[WIP] Sort assignments in sets and "let"

### DIFF
--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -67,6 +67,7 @@ library
     Nixfmt.Parser
     Nixfmt.Predoc
     Nixfmt.Pretty
+    Nixfmt.Transform
     Nixfmt.Types
     Nixfmt.Util
   other-extensions:    OverloadedStrings, LambdaCase, FlexibleInstances, DeriveFoldable, DeriveFunctor, StandaloneDeriving

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -11,16 +11,20 @@ module Nixfmt
     ) where
 
 import Data.Text (Text)
+import Data.Semigroup (appEndo)
 import Text.Megaparsec (parse)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 import Nixfmt.Parser (file)
 import Nixfmt.Predoc (layout)
 import Nixfmt.Pretty ()
+import Nixfmt.Transform (sortKeys)
 import Nixfmt.Types (ParseErrorBundle)
 
 -- | @format w filename source@ returns either a parsing error specifying a
 -- failure in @filename@ or a formatted version of @source@ with a maximum width
 -- of @w@ columns where possible.
 format :: Int -> FilePath -> Text -> Either ParseErrorBundle Text
-format width filename = fmap (layout width) . parse file filename
+format width filename = fmap (layout width . transform) . parse file filename
+  where
+    transform = appEndo sortKeys

--- a/src/Nixfmt/Transform.hs
+++ b/src/Nixfmt/Transform.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE LambdaCase, OverloadedStrings #-}
+module Nixfmt.Transform (sortKeys) where
+import Data.List (sortBy)
+import Data.Ord (comparing)
+import Data.Semigroup (Endo(..))
+import Data.Text (Text)
+import Nixfmt.Types
+
+-- Normalize order of set keys are let assignments, transforming, for
+-- example
+--
+-- let
+--   d = 3;
+--   c = 4;
+--   e = 5;
+-- in {
+--   inherit e;
+--   b = d;
+--   a = c;
+-- }
+--
+-- into
+--
+--   let
+--     c = 4;
+--     d = 3;
+--     e = 5;
+--   in {
+--     a = c;
+--     b = d;
+--     inherit e;
+--   }
+--
+-- Keys are sorted alphabetically, "inherit" expression moved below
+-- assignments.
+
+sortKeys :: Endo File
+sortKeys = Endo $ \(File ann expr) -> File ann (sortKeysExpr expr)
+
+-- XXX: Here I re-invent Data.Data.
+omapT :: (Term -> Term) -> Term -> Term
+omapT f = go
+  where
+    go = \case
+      List x subs y -> f $ List x (map go subs) y
+      e -> f e
+
+omapE :: (Expression -> Expression) -> Expression -> Expression
+omapE f = go
+  where
+    go = f . \case
+      Term x -> Term x
+      With l1 e1 l2 e2 -> With l1 (go e1) l2 (go e2)
+      Let l1 b l2 e -> Let l1 b l2 (go e)
+      Assert l1 e1 l2 e2 -> Assert l1 (go e1) l2 (go e2)
+      If l1 e1 l2 e2 l3 e3 -> If l1 (go e1) l2 (go e2) l3 (go e3)
+      Abstraction p l e -> Abstraction p l (go e)
+      Application e1 e2 -> Application (go e1) (go e2)
+      Operation e1 l e2 -> Operation (go e1) l (go e2)
+      MemberCheck e1 l s -> MemberCheck (go e1) l s
+      Negation l e -> Negation l (go e)
+      Inversion l e -> Inversion l (go e)
+
+sortKeysExpr :: Expression -> Expression
+sortKeysExpr = omapE sortE
+  where
+    sortE = \case
+      Let l1 b l2 e -> Let l1 (sortBinders b) l2 e;
+      Term x -> Term $ omapT sortT x
+      e -> e
+    sortT = \case
+      Set l1 l2 b l3 -> Set l1 l2 (sortBinders b) l3
+      t -> t
+
+sortBinders :: [Binder] -> [Binder]
+sortBinders = sortBy (comparing keyB)
+  where
+    -- And here I reinvent lens.
+    keyB :: Binder -> (Int, [(Int, Maybe Text)])
+    keyB = \case
+      Assignment sels _ _ _ -> (0, map keyS sels)
+      Inherit _ _ names _   -> (1, map (\x -> (0, keyL x)) names)
+
+    keyS :: Selector -> (Int, Maybe Text)
+    keyS (Selector _ ss _) = keySS ss
+
+    keySS :: SimpleSelector -> (Int, Maybe Text)
+    keySS = \case
+      -- Interpolation can contain arbitrary sub-expression and is too
+      -- complicated to sort. Just put it below regular identifiers.
+      IDSelector l -> (0, keyL l)
+      _            -> (1, Nothing)
+
+    keyL :: Leaf -> Maybe Text
+    keyL (Ann t _ _) = keyT t
+
+    keyT :: Token -> Maybe Text
+    keyT = \case
+      Identifier txt -> Just txt
+      _ -> Nothing
+


### PR DESCRIPTION
Sort alphabetically identifier keys in sets and let abstraction. More
complex ways to specify keys, like "inherit" statement or interpolated
sorts after plain identifier keys, but without any meaningful order
between themself.

With this change expression "{ b = 10; a = 15; }" transformed into
"{ a = 15; b = 10; }", as indented. Things are getting trickier with
comments.

Nixfmt preserves comments by attaching them to tokens before comment.
It may result to unexpected behaviour in following quite natural case:

	{
	  b = 12; # talk about "b"

	  # This is comment about "a"
	  a = 10;
	}

This expression gets transformed into following, since from Nixfmt point
of view both comments are attached to "b = 12;" assignment (semicolon,
to be more precise).

	{
	  a = 10;
	  b = 12; # talk about "b"

	  # This is comment about "a"
	}

*DISCUSSION*: What should be done about this unexpected behaviour with
comments?

First option is just make this feature opt-in. Second one, probably
harder, it to use some heuristics on whether comment should be attached
to token before or after comment. This is the most complex case I
managed to invent:

	FunctionFoo { # comment on set. Dont't move!
	  # comment on b, move with b.
	  b = 42; # this is also comment on b.

	  # comment on a.
	  a = 14;

	  c = [ # comment on array
	    1
	    2
	    3
	  ]; # comment on c;
	}

Seems that rule "comment that takes whole line is attached to token
after it, otherwise it is attached to token before it" is good
approximation of human perception.

Dear maintainer, what do you suggest and implementation of what approach
you are willing to accept?