### PR TITLE
Create team document

### DIFF
--- a/team/README.md
+++ b/team/README.md
@@ -1,0 +1,40 @@
+<!-- © 2024 Silvan Mosberger <contact@infinisil.com>
+   -
+   - SPDX-License-Identifier: MPL-2.0
+   -->
+
+# Nix formatting team
+
+This page collects information and processes for the Nix formatting team.
+
+## Links
+
+- GitHub team: [@NixOS/nix-formatting](https://github.com/orgs/NixOS/teams/nix-formatting/members)
+- Matrix room: [#nix-formatting:nixos.org](https://matrix.to/#/#nix-formatting:nixos.org)
+- Meeting calendar: [Search for "Nix formatting"](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com)
+- Meeting link: [Jitsi](https://meet.zrh.init7.net/nix-formatting)
+- Live meeting notes: [HedgeDoc](https://pad.lassul.us/nix-formatting)
+
+## Responsibilities
+
+The responsibilities of team members are:
+- Responding to personal pings in the Matrix room and GitHub issues/PRs for this repository
+- Reviewing PRs of this repository when requested
+
+The team lead has additional responsibilities:
+- Keeping track of tasks
+- Posting meeting notes
+- Managing permissions
+- Keeping team information up-to-date
+
+## Processes
+
+After every meeting, the notes must be posted to [Discourse](https://discourse.nixos.org/)
+
+For all non-trivial decisions:
+- At least 2 members must reach consensus
+  - This can be on Matrix, GitHub or in meetings
+- The decision must be publicly documented, in any of:
+  - GitHub issues/PRs
+  - Design documents in the repository
+  - Meeting notes


### PR DESCRIPTION
Adds very basic team documentation as outlined in https://github.com/serokell/nixfmt/issues/153

Please review @piegamesde, @Sereja313, @dasJ, @0x4A6F, @tomberek