### PR TITLE
ci: remove deploy and fix after repo transfer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,49 +10,17 @@ on:
     branches:
       - master
 
-env:
-  CDN_DISTRIBUTION_ID: E13UN1J1JFIWUZ
-  CDN_BUCKET: s3://nixfmt.serokell.io
-
 jobs:
   check:
-    runs-on: [self-hosted, nix]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v26
 
       - name: reuse lint
         run: nix shell .#packages.x86_64-linux.reuse -c reuse lint
 
-      # - name: hlint
-      #   run: nix build -L .#checks.x86_64-linux.hlint
-      #   if: success() || failure()
-
-      # - name: stylish-haskell
-      #   run: nix build -L .#checks.x86_64-linux.stylish-haskell
-      #   if: success() || failure()
-
       - name: build nixfmt
         run: nix build -L .#nixfmt-static
         if: success() || failure()
-
-      - name: build webdemo
-        run: nix build -L .#nixfmt-webdemo
-        if: success() || failure()
-
-      - name: build awscli
-        run: nix shell .#awscli
-        if: success() || failure()
-
-  deploy:
-    runs-on: [self-hosted, nix]
-    if: ${{ github.ref == 'refs/heads/master' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: deploy webdemo
-        run: |
-          nix build .#nixfmt-webdemo
-          nix shell .#awscli -c aws s3 cp --recursive result/ "$CDN_BUCKET"
-          # delete files that don't exist anymore, use `--size-only` so behavior won't depend on local file timestamps
-          nix shell .#awscli -c aws s3 sync --delete --size-only result/ "$CDN_BUCKET"
-          nix shell .#awscli -c aws cloudfront create-invalidation --distribution-id "$CDN_DISTRIBUTION_ID" --paths '/*'


### PR DESCRIPTION
The web demo will be retired from this repo soon anyways, see https://github.com/NixOS/nixfmt/issues/157

I believe it also relied on using Serokell's self-hosted action runners, which we can't use anymore now that the repo has been transferred, so we use the default ubuntu-latest instead.