### PR TITLE
Nix improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: cachix/install-nix-action@v26
 
       - name: reuse lint
-        run: nix shell .#packages.x86_64-linux.reuse -c reuse lint
+        run: nix-build -A packages.reuse && result/bin/reuse lint
 
       - name: build nixfmt
-        run: nix build -L .
+        run: nix-build
         if: success() || failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
         run: nix shell .#packages.x86_64-linux.reuse -c reuse lint
 
       - name: build nixfmt
-        run: nix build -L .#nixfmt-static
+        run: nix build -L .
         if: success() || failure()

--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,6 @@ build
 // rec {
   packages = {
     nixfmt = build;
-    nixfmt-deriver = build.cabal2nixDeriver;
 
     nixfmt-shell = packages.nixfmt.env.overrideAttrs (oldAttrs: {
       buildInputs =

--- a/default.nix
+++ b/default.nix
@@ -58,6 +58,7 @@ build
     nativeBuildInputs = with pkgs; [
       cabal-install
       stylish-haskell
+      haskellPackages.haskell-language-server
       shellcheck
       npins
     ];

--- a/default.nix
+++ b/default.nix
@@ -40,14 +40,17 @@ let
     ];
   };
 
-  build = pkgs.haskellPackages.nixfmt;
+  build = lib.pipe pkgs.haskellPackages.nixfmt [
+    haskell.lib.justStaticExecutables
+    haskell.lib.dontHaddock
+    (drv: lib.lazyDerivation { derivation = drv; })
+  ];
 in
 build
 // rec {
   packages = {
     nixfmt = build;
-    nixfmt-static = haskell.lib.justStaticExecutables packages.nixfmt;
-    nixfmt-deriver = packages.nixfmt-static.cabal2nixDeriver;
+    nixfmt-deriver = build.cabal2nixDeriver;
 
     nixfmt-shell = packages.nixfmt.env.overrideAttrs (oldAttrs: {
       buildInputs =

--- a/default.nix
+++ b/default.nix
@@ -47,26 +47,21 @@ let
   ];
 in
 build
-// rec {
+// {
   packages = {
     nixfmt = build;
-
-    nixfmt-shell = packages.nixfmt.env.overrideAttrs (oldAttrs: {
-      buildInputs =
-        oldAttrs.buildInputs
-        ++ (with pkgs; [
-          # nixfmt: expand
-          cabal-install
-          stylish-haskell
-          shellcheck
-          npins
-        ]);
-    });
-
     inherit (pkgs) reuse;
   };
 
-  shell = packages.nixfmt-shell;
+  shell = pkgs.haskellPackages.shellFor {
+    packages = p: [ p.nixfmt ];
+    nativeBuildInputs = with pkgs; [
+      cabal-install
+      stylish-haskell
+      shellcheck
+      npins
+    ];
+  };
 
   checks = {
     hlint = pkgs.build.haskell.hlint ./.;

--- a/default.nix
+++ b/default.nix
@@ -30,23 +30,14 @@ let
 
   inherit (pkgs) haskell lib;
 
-  regexes = [
-    ".*.cabal$"
-    "^src.*"
-    "^main.*"
-    "^Setup.hs$"
-    "^js.*"
-    "LICENSE"
-  ];
-  src = builtins.path {
-    path = ./.;
-    name = "nixfmt-src";
-    filter =
-      path: type:
-      let
-        relPath = lib.removePrefix (toString ./. + "/") (toString path);
-      in
-      lib.any (re: builtins.match re relPath != null) regexes;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./nixfmt.cabal
+      ./src
+      ./main
+      ./LICENSE
+    ];
   };
 
   build = pkgs.haskellPackages.nixfmt;

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
         apps.default = {
           type = "app";
-          program = "${self.packages.${system}.nixfmt-static}/bin/nixfmt";
+          program = "${result}/bin/nixfmt";
         };
 
         checks = result.checks;


### PR DESCRIPTION
Various improvements to the Nix code:
- Use the new [`lib.fileset`](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset) library instead of `builtins.path` and regex based source filtering
- Fix https://github.com/NixOS/nixfmt/issues/143 by always using `justStaticExecutables` (doesn't mean the binaries are statically linked confusingly)
- Don't build the haddocks anymore, we won't need those anyways with https://github.com/NixOS/nixfmt/issues/161
- Remove `nixfmt-deriver`, doesn't seem necessary
- Switch to `haskellPackages.shellFor`, a bit cleaner
- Add [haskell-language-server](https://github.com/haskell/haskell-language-server) to the environment, makes development very nice!