### PR TITLE
Condense REUSE 3.0 copyright and license notes

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,34 +1,8 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-Files: .github/ISSUE_TEMPLATE/formatting-suggestion.md
-Copyright: 2019 Serokell <hi@serokell.io>
-           2019 Lars Jellema <lars.jellema@gmail.com>
-License: MPL-2.0
-
-Files: npins/*
-Copyright: 2024 Silvan Mosberger <contact@infinisil.com>
-License: MPL-2.0
-
-Files: test/diff/*
-Copyright: 2024 piegames <git@piegames.de>
-License: MPL-2.0
-
-Files: test/correct/*
-Copyright: 2022 Serokell <hi@serokell.io>
-           2022 Lars Jellema <lars.jellema@gmail.com>
-License: MPL-2.0
-
-Files: test/changed/*
-Copyright: 2022 Serokell <hi@serokell.io>
-           2022 Lars Jellema <lars.jellema@gmail.com>
-License: MPL-2.0
-
-Files: test/invalid/*
-Copyright: 2022 Serokell <hi@serokell.io>
-           2022 Lars Jellema <lars.jellema@gmail.com>
-License: MPL-2.0
-
-Files: flake.lock
-Copyright: 2020 Serokell <hi@serokell.io>
-           2022 Yorick van Pelt <yorickvanpelt@gmail.com>
+Files: *
+Copyright: 2019-2022 Serokell <hi@serokell.io>
+           2019-2022 Lars Jellema <lars.jellema@gmail.com>
+           2023-2024 piegames <git@piegames.de>
+           2024 Silvan Mosberger <contact@infinisil.com>
 License: MPL-2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-<!-- © 2019 Serokell <hi@serokell.io>
-   - © 2019 Lars Jellema <lars.jellema@gmail.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
-
 # Revision history for nixfmt
 
 ## Unreleased

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,3 @@
-<!-- © 2019 Serokell <hi@serokell.io>
-   - © 2019 Lars Jellema <lars.jellema@gmail.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 # Contribution Guidelines
 
 We welcome issues and pull requests at https://github.com/serokell/nixfmt.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,8 +1,3 @@
-<!-- © 2023 piegames <git@piegames.de>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 # Maintainer documentation
 
 ## Making a new release

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<!-- © 2019 Serokell <hi@serokell.io>
-   - © 2019 Lars Jellema <lars.jellema@gmail.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 # `nixfmt`
 
 `nixfmt` is a formatter for Nix code, intended to easily apply a uniform style.

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,3 @@
-# © 2019 Serokell <hi@serokell.io>
-# © 2019 Lars Jellema <lars.jellema@gmail.com>
-# © 2024 Silvan Mosberger <contact@infinisil.com>
-#
-# SPDX-License-Identifier: MPL-2.0
-
 let
   sources = import ./npins;
 in

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,3 @@
-# © 2019 Serokell <hi@serokell.io>
-# © 2019 Lars Jellema <lars.jellema@gmail.com>
-#
-# SPDX-License-Identifier: MPL-2.0
 {
 
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE DeriveDataTypeable, NamedFieldPuns, MultiWayIf #-}
 
 module Main where

--- a/main/System/IO/Atomic.hs
+++ b/main/System/IO/Atomic.hs
@@ -1,8 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 -- | Atomic file IO.
 --
 -- This modules allows one to replace the contents of a file atomically by

--- a/main/System/IO/Utf8.hs
+++ b/main/System/IO/Utf8.hs
@@ -1,8 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -1,10 +1,4 @@
 cabal-version:       2.0
-
--- © 2022 Serokell <hi@serokell.io>
--- © 2022 Lars Jellema <lars.jellema@gmail.com>
---
--- SPDX-License-Identifier: MPL-2.0
-
 name:                nixfmt
 version:             0.6.0
 synopsis:            An opinionated formatter for Nix

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,1 @@
-# © 2024 Silvan Mosberger <contact@infinisil.com>
-# SPDX-License-Identifier: MPL-2.0
 (import ./default.nix { }).shell

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 module Nixfmt
     ( errorBundlePretty
     , ParseErrorBundle

--- a/src/Nixfmt/Lexer.hs
+++ b/src/Nixfmt/Lexer.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE BlockArguments, FlexibleContexts, LambdaCase, OverloadedStrings, TupleSections #-}
 
 module Nixfmt.Lexer (lexeme, pushTrivia, takeTrivia, whole) where

--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE FlexibleInstances, OverloadedStrings #-}
 
 module Nixfmt.Parser where

--- a/src/Nixfmt/Parser/Float.hs
+++ b/src/Nixfmt/Parser/Float.hs
@@ -1,9 +1,3 @@
-{- © 2022 Serokell <hi@serokell.io>
- - © 2022 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE TypeFamilies, TypeApplications, ScopedTypeVariables, TypeOperators #-}
 
 module Nixfmt.Parser.Float (floatParse) where

--- a/src/Nixfmt/Predoc.hs
+++ b/src/Nixfmt/Predoc.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE FlexibleInstances, OverloadedStrings, LambdaCase #-}
 
 module Nixfmt.Predoc

--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE FlexibleInstances, OverloadedStrings, RankNTypes, TupleSections, LambdaCase #-}
 
 module Nixfmt.Pretty where

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE DeriveFoldable, OverloadedStrings, RankNTypes, LambdaCase, TupleSections, FlexibleInstances #-}
 
 module Nixfmt.Types where

--- a/src/Nixfmt/Util.hs
+++ b/src/Nixfmt/Util.hs
@@ -1,9 +1,3 @@
-{- © 2019 Serokell <hi@serokell.io>
- - © 2019 Lars Jellema <lars.jellema@gmail.com>
- -
- - SPDX-License-Identifier: MPL-2.0
- -}
-
 {-# LANGUAGE TupleSections #-}
 
 module Nixfmt.Util

--- a/standard.md
+++ b/standard.md
@@ -1,9 +1,3 @@
-<!-- © 2024 piegames <git@piegames.de>
-   - © 2024 Silvan Mosberger <contact@infinisil.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 # Standard Nix format
 
 This document describes the standard Nix format, as first established [by RFC 166](https://github.com/NixOS/rfcs/blob/master/rfcs/0166-nix-formatting.md#standard-nix-format).

--- a/team/README.md
+++ b/team/README.md
@@ -1,8 +1,3 @@
-<!-- © 2024 Silvan Mosberger <contact@infinisil.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 # Nix formatting team
 
 This page collects information and processes for the Nix formatting team.

--- a/test/README.md
+++ b/test/README.md
@@ -1,9 +1,3 @@
-<!-- © 2022 Serokell <hi@serokell.io>
-   - © 2022 Lars Jellema <lars.jellema@gmail.com>
-   -
-   - SPDX-License-Identifier: MPL-2.0
-   -->
-
 Tests in `correct` are formatted the way they should be.
 Running `nixfmt --verify` on them should result in the output being the same as
 the input.

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# © 2024 piegames <git@piegames.de>
-# SPDX-License-Identifier: MPL-2.0
 
 set -euo pipefail
 


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixfmt/issues/164, we want to avoid requiring copyright notices in each file and instead condense them into a single place.

All copyright holders agreed to doing this already, but it would still be good to get an approval on this PR.

Note that I didn't remove REUSE 3.0, but just kind of cheated by using `*` to set the copyright for all files (I hope that works, we'll see when CI runs..) :)

Ping @Sereja313 @gromakovsky @piegamesde @Lucus16 