### PR TITLE
Remove leftover license/author mentions and fix more Serokell references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,3 @@
-# © 2019-2023 Serokell <hi@serokell.io>
-# © 2019-2023 Lars Jellema <lars.jellema@gmail.com>
-#
-# SPDX-License-Identifier: MPL-2.0
-
 name: CI
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# © 2019 Serokell <hi@serokell.io>
-# © 2019 Lars Jellema <lars.jellema@gmail.com>
-#
-# SPDX-License-Identifier: MPL-2.0
-
 /.cabal-sandbox/
 /cabal.sandbox.config
 /dist/

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,8 +1,3 @@
-# © 2019 Serokell <hi@serokell.io>
-# © 2019 Lars Jellema <lars.jellema@gmail.com>
-#
-# SPDX-License-Identifier: MPL-2.0
-
 steps:
   - simple_align:
       cases: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-We welcome issues and pull requests at https://github.com/serokell/nixfmt.
+We welcome issues and pull requests at https://github.com/NixOS/nixfmt.
 
 We use stylish-haskell to format our code. Make sure to format your
 contributions with it. It is available within the `nix-shell` and it should pick

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 You are encouraged to test this out on your code and submit any undesirable formatting you find as an issue
 
-![Build Status](https://github.com/serokell/nixfmt/actions/workflows/main.yml/badge.svg?branch=master)
+![Build Status](https://github.com/NixOS/nixfmt/actions/workflows/main.yml/badge.svg?branch=master)
 
 ## State
 
@@ -12,7 +12,7 @@ You are encouraged to test this out on your code and submit any undesirable form
 
 The established standard Nix formatting differs considerably from the original one. Be aware of this if you track the main branch. Until the first new release the main branch should be considered **very unstable**.
 
-For more details, see the [RFC implementation tracking issue](https://github.com/serokell/nixfmt/issues/153).
+For more details, see the [RFC implementation tracking issue](https://github.com/NixOS/nixfmt/issues/153).
 
 ## Installation
 
@@ -22,11 +22,11 @@ For more details, see the [RFC implementation tracking issue](https://github.com
 
 - To get the most recent version, install from master:
 
-      nix-env -f https://github.com/serokell/nixfmt/archive/master.tar.gz -i
+      nix-env -f https://github.com/NixOS/nixfmt/archive/master.tar.gz -i
 
 - Nix with flakes
 
-      nix profile install github:serokell/nixfmt
+      nix profile install github:NixOS/nixfmt
 
 ## Development
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -5,20 +5,19 @@ synopsis:            An opinionated formatter for Nix
 description:
   A formatter for Nix that ensures consistent and clear formatting by forgetting
   all existing formatting during parsing.
-homepage:            https://github.com/serokell/nixfmt
-bug-reports:         https://github.com/serokell/nixfmt/issues
+homepage:            https://github.com/NixOS/nixfmt
+bug-reports:         https://github.com/NixOS/nixfmt/issues
 license:             MPL-2.0
 license-file:        LICENSE
-author:              Lars Jellema
-maintainer:          lars.jellema@gmail.com
-copyright:           2022 Serokell, 2022 Lars Jellema
+author:              Serokell <hi@serokell.io> and nixfmt contributors
+copyright:           Serokell <hi@serokell.io> and nixfmt contributors
 category:            Development
 build-type:          Simple
 extra-source-files:  README.md, CHANGELOG.md
 
 source-repository head
   type:     git
-  location: git://github.com/serokell/nixfmt.git
+  location: git://github.com/NixOS/nixfmt.git
 
 executable nixfmt
   main-is:             Main.hs

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -62,7 +62,7 @@ formatVerify width path unformatted = do
     else Right formattedOnce
     where
         parse = first errorBundlePretty . Megaparsec.parse file path
-        pleaseReport x = path <> ": " <> x <> " This is a bug in nixfmt. Please report it at https://github.com/serokell/nixfmt"
+        pleaseReport x = path <> ": " <> x <> " This is a bug in nixfmt. Please report it at https://github.com/NixOS/nixfmt"
 
 
 minimize :: Expression -> (Expression -> Bool) -> Expression


### PR DESCRIPTION
The Serokell references now point to the NixOS org. I also removed the maintainer field from the cabalfile since there isn't a single maintainer.