### PR TITLE
Remove individuals from copyright in favor of "nixfmt contributors"

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,7 +2,5 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
 Copyright: 2019-2022 Serokell <hi@serokell.io>
-           2019-2022 Lars Jellema <lars.jellema@gmail.com>
-           2023-2024 piegames <git@piegames.de>
-           2024 Silvan Mosberger <contact@infinisil.com>
+           2019-2024 Nixfmt Contributors
 License: MPL-2.0


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixfmt/issues/169

While this does change the copyright notice, which is technically not allowed by MPL-2.0 https://github.com/NixOS/nixfmt/blob/b84dba1c7b4c3eff2faf8cbc47381a2ad2be5734/LICENSE#L198-L204

I believe it should be fine if we can get all of the individuals approval. @Lucus16 already indicated approval in https://github.com/NixOS/nixfmt/issues/169#issuecomment-2008122683:

> In my case I don't mind you removing my copyright notices

I'm also fine with my name being removed.

We only need @piegamesde's explicit approval now.

Note that this doesn't remove the copyright of the contributions, it just changes the copyright note.

CC @Sereja313 @gromakovsky