### PR TITLE
Fix duplicate Nixpkgs diff comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
+        id: couc
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -66,7 +67,7 @@ jobs:
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
+          comment-id: ${{ steps.couc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
           body: |


### PR DESCRIPTION
A duplicate comment is posted when the action runs the first time, because the posted comment isn't reused.

This could be seen in https://github.com/NixOS/nixfmt/pull/185, and it shouldn't happen in this PR anymore.