### PR TITLE
Nixpkgs diff for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,11 @@ jobs:
 
       - uses: cachix/install-nix-action@v26
 
+      - uses: cachix/cachix-action@v14
+        with:
+          name: nixos-nixfmt
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: checks
         run: nix-build -A ci
 
@@ -67,6 +72,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v26
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: nixos-nixfmt
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - run: |
           ./scripts/sync-pr.sh \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,6 @@ on:
     branches:
       - master
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -38,6 +34,10 @@ jobs:
   nixpkgs-diff:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target'
+    # Ensures that we don't run two comment-posting workflows at the same time
+    concurrency:
+      group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,21 +17,8 @@ jobs:
 
       - uses: cachix/install-nix-action@v26
 
-      - name: reuse lint
-        run: nix-build -A packages.reuse && result/bin/reuse lint
-
-      - name: hlint
-        run: nix-build -A checks.hlint
-
-      - name: treefmt
-        run: nix-build -A checks.treefmt
-
-      - name: build nixfmt
-        run: nix-build
-        if: success() || failure()
-
-      - name: run tests
-        run: nix-shell --run ./test/test.sh
+      - name: checks
+        run: nix-build -A checks
 
   nixpkgs-diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 on:
-  pull_request:
+  # We use pull_request_target such that Nixpkgs diff processing also works,
+  # because we need repository secrets for that, which pull_request doesn't allow from forks.
+  # However, it's very important that we don't run code from forks without sandboxing it,
+  # because that way anybody could potentially extract repository secrets!
+  pull_request_target:
   push:
     branches:
       - master
@@ -14,6 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          # To prevent running untrusted code from forks,
+          # pull_request_target will cause the base branch to be checked out, not the PR branch.
+          # In our case we check out the PR branch regardless,
+          # because we're sandboxing all untrusted code with a `nix-build`.
+          # (and the sandbox is enabled by default at least on Linux)
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - uses: cachix/install-nix-action@v26
 
@@ -22,7 +37,7 @@ jobs:
 
   nixpkgs-diff:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v3
@@ -44,6 +59,11 @@ jobs:
 
             Will be available [here](https://github.com/${{ vars.MACHINE_USER }}/nixpkgs/commits/nixfmt-${{ github.event.pull_request.number }})
 
+      # To prevent running untrusted code from forks,
+      # pull_request_target will cause the base branch to be checked out, not the PR branch.
+      # This is exactly what we want in this case,
+      # because the sync-pr.sh script cannot be run sandboxed since it needs to have side effects.
+      # Instead, the script itself fetches the PR, but then runs its code within sandboxed derivations.
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v26

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: cachix/install-nix-action@v26
 
       - name: checks
-        run: nix-build -A checks
+        run: nix-build -A ci
 
   nixpkgs-diff:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /dist/
 /dist-newstyle
 /.ghc.environment.*
-/result
+/result*
 /.direnv

--- a/default.nix
+++ b/default.nix
@@ -75,25 +75,6 @@ let
     # Haskell formatter
     programs.fourmolu.enable = true;
   };
-in
-build
-// {
-  packages.nixfmt = build;
-
-  inherit pkgs;
-
-  shell = pkgs.haskellPackages.shellFor {
-    packages = p: [ p.nixfmt ];
-    nativeBuildInputs = with pkgs; [
-      cabal-install
-      stylish-haskell
-      haskellPackages.haskell-language-server
-      shellcheck
-      npins
-      hlint
-      treefmtEval.config.build.wrapper
-    ];
-  };
 
   checks = {
     inherit build;
@@ -121,4 +102,27 @@ build
     };
     treefmt = treefmtEval.config.build.check source;
   };
+in
+build
+// {
+  packages.nixfmt = build;
+
+  inherit pkgs;
+
+  shell = pkgs.haskellPackages.shellFor {
+    packages = p: [ p.nixfmt ];
+    nativeBuildInputs = with pkgs; [
+      cabal-install
+      stylish-haskell
+      haskellPackages.haskell-language-server
+      shellcheck
+      npins
+      hlint
+      treefmtEval.config.build.wrapper
+    ];
+  };
+
+  inherit checks;
+
+  ci = pkgs.linkFarm "ci" checks;
 }

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,8 @@ build
 // {
   packages.nixfmt = build;
 
+  inherit pkgs;
+
   shell = pkgs.haskellPackages.shellFor {
     packages = p: [ p.nixfmt ];
     nativeBuildInputs = with pkgs; [

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,16 @@ let
     haskell = super.haskell // {
       packageOverrides = self: super: { nixfmt = self.callCabal2nix "nixfmt" src { }; };
     };
+
+    treefmt = super.treefmt.overrideAttrs (old: {
+      patches = [
+        # Makes it work in parallel: https://github.com/numtide/treefmt/pull/282
+        (self.fetchpatch {
+          url = "https://github.com/numtide/treefmt/commit/f596795cd24b50f048cc395866bb90a89d99152d.patch";
+          hash = "sha256-EPn+JAT3aZLSWmpdi9ULZ8o8RvrX+UFp0cQWfBcQgVg=";
+        })
+      ];
+    });
   };
 
   pkgs = import nixpkgs {

--- a/scripts/sync-pr-support.nix
+++ b/scripts/sync-pr-support.nix
@@ -1,0 +1,49 @@
+/*
+  This file supports the ./sync-pr.sh script with some Nix code.
+  Note that we are not using the nixfmt from the tree of this file,
+  instead the nixfmt to use is passed into the necessary function.
+  This way we don't need to rely on this internal file being stable.
+*/
+let
+  pkgs = (import ../default.nix { }).pkgs;
+  inherit (pkgs) lib;
+in
+{
+  # Filters a repo into a store path only containing its Git-tracked Nix files
+  repoNixFiles =
+    { repo }:
+    lib.fileset.toSource {
+      root = repo;
+      fileset = lib.fileset.intersection (lib.fileset.gitTracked repo) (
+        lib.fileset.fileFilter (file: file.hasExt "nix") repo
+      );
+    };
+
+  # Returns a derivation that contains the passed store path (e.g. from the above function)
+  # but with all Nix files formatted with the given nixfmt
+  formattedGitRepo =
+    { storePath, nixfmtPath }:
+    let
+      nixfmt = (import nixfmtPath { }).packages.nixfmt;
+    in
+    pkgs.runCommand "formatted"
+      {
+        nativeBuildInputs = with pkgs; [
+          treefmt
+          nixfmt
+        ];
+        treefmtConfig = ''
+          [formatter.nixfmt-rfc-style]
+          command = "nixfmt"
+          includes = [ "*.nix" ]
+        '';
+        passAsFile = [ "treefmtConfig" ];
+      }
+      ''
+        cp -r --no-preserve=mode ${builtins.storePath storePath} $out
+        treefmt \
+          --config-file "$treefmtConfigPath" \
+          --tree-root "$out" \
+          --no-cache
+      '';
+}

--- a/scripts/sync-pr.sh
+++ b/scripts/sync-pr.sh
@@ -181,9 +181,12 @@ else
           echo "Checking whether commit with index $(( nixpkgsCommitCount + 1 )) ($nixpkgsCommit) in nixpkgs corresponds to commit with index $nixpkgsCommitCount ($nixfmtCommit) in nixfmt"
 
           # We generate the bodies of the commits to contain the nixfmt commit so we can check against it here to verify it's the same
-          body=$(git -C nixpkgs.git log -1 "$nixpkgsCommit" --pretty=%B)
-          expectedBody=$(bodyForCommitIndex "$nixpkgsCommitCount")
-          if [[ "$body" == "$expectedBody" ]]; then
+          # Note that `--format=format:` makes it so that there's no extra newline
+          git -C nixpkgs.git log -1 "$nixpkgsCommit" --format=format:%B > "$tmp/body"
+          bodyForCommitIndex "$nixpkgsCommitCount" > "$tmp/expected-body"
+
+          # Ignore case so that we don't need to be worried about things like NixOS vs nixos in the URL
+          if diff --ignore-case "$tmp/body" "$tmp/expected-body"; then
             echo "It does!"
           else
             echo "It does not, this indicates a force push was done"

--- a/scripts/sync-pr.sh
+++ b/scripts/sync-pr.sh
@@ -49,7 +49,7 @@ isLinear() {
 }
 
 step "Fetching nixfmt pull request and creating a branch for the head commit"
-git init nixfmt
+git init nixfmt -b unused
 git -C nixfmt fetch "$nixfmtUrl" "refs/pull/$nixfmtPrNumber/merge"
 nixfmtBaseCommit=$(git -C nixfmt rev-parse FETCH_HEAD^1)
 nixfmtHeadCommit=$(git -C nixfmt rev-parse FETCH_HEAD^2)
@@ -97,7 +97,7 @@ bodyForCommitIndex() {
 }
 
 step "Fetching upstream Nixpkgs commit history"
-git init --bare nixpkgs.git
+git init --bare nixpkgs.git -b unused
 
 git -C nixpkgs.git remote add upstream "$nixpkgsUpstreamUrl"
 # This makes sure that we don't actually have to fetch any contents, otherwise we'd wait forever!
@@ -201,16 +201,16 @@ else
 fi
 
 
-git init nixpkgs
+git init nixpkgs -b unused
 git -C nixpkgs config user.name "GitHub Actions"
 git -C nixpkgs config user.email "actions@users.noreply.github.com"
 
 step "Fetching contents of Nixpkgs base commit $nixpkgsBaseCommit"
 # This is needed because for every commit we reset Nixpkgs to the base branch before formatting
-git -C nixpkgs fetch --no-tags --depth 1 "$nixpkgsUpstreamUrl" "$nixpkgsBaseCommit"
+git -C nixpkgs fetch --no-tags --depth 1 "$nixpkgsUpstreamUrl" "$nixpkgsBaseCommit":base
 
 step "Checking out Nixpkgs at the base commit"
-git -C nixpkgs checkout "$nixpkgsBaseCommit"
+git -C nixpkgs checkout base
 
 # Because we run the formatter in a Nix derivation, we need to get its input files into the Nix store.
 # Since they never change, it would be wasteful to import them multiple times for each nixfmt run.
@@ -257,7 +257,7 @@ next() {
   update "$index"
 
   step "Checking out Nixpkgs at the base commit"
-  git -C nixpkgs checkout "$nixpkgsBaseCommit" -- .
+  git -C nixpkgs checkout base -- .
 
   step "Running nixfmt on nixpkgs in a derivation"
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -12,7 +12,13 @@ shellcheck "$0"
 cd "$(dirname "$0")/.."
 
 shopt -s expand_aliases
-alias nixfmt="cabal v2-run --verbose=0 nixfmt -- -w 80"
+if command -v cabal &> /dev/null; then
+  # If we have cabal we're probably developing
+  alias nixfmt="cabal v2-run --verbose=0 nixfmt -- -w 80"
+else
+  # Otherwise assume we're in CI, where instead nixfmt will be prebuilt
+  alias nixfmt="nixfmt -w 80"
+fi
 
 # Do a test run to make sure it compiles fine
 nixfmt --version


### PR DESCRIPTION
This is super tricky stuff, but this should allow us to run the Nixpkgs diff for forks without safety issues (e.g. for #193). See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for some background.

Also included is:
- https://github.com/numtide/treefmt/pull/282
- Some related Nix and CI improvements

Best reviewed commit-by-commit.

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: