### PR TITLE
Use --verify in Nixpkgs diff CI

### DIFF
--- a/scripts/sync-pr-support.nix
+++ b/scripts/sync-pr-support.nix
@@ -35,6 +35,7 @@ in
         treefmtConfig = ''
           [formatter.nixfmt-rfc-style]
           command = "nixfmt"
+          options = [ "--verify" ]
           includes = [ "*.nix" ]
         '';
         passAsFile = [ "treefmtConfig" ];


### PR DESCRIPTION
Makes sure that when testing formatting on all of Nixpkgs, the AST doesn't change, important for https://github.com/NixOS/nixpkgs/issues/322520

This does make the Nixpkgs diff CI like 1 minute slower per commit, but this seems worth it.

- [x] Fixed idempotency bugs (included in this PR for testing)
  - #219 
  - #220 
- [x] Confirmed that CI fails if the AST is modified: https://github.com/NixOS/nixfmt/pull/216 ([logs](https://github.com/NixOS/nixfmt/actions/runs/9912313132/job/27386897317?pr=216))

Also discovered another bug from this, fix: #217 