### PR TITLE
Fix non-idempotent comments in attribute parameters

### DIFF
--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -269,11 +269,11 @@ moveParamsComments
   -- # comment
   -- , name2
   ( (ParamAttr name maybeDefault (Just (Ann trivia comma Nothing)))
-      : (ParamAttr (Ann trivia' name' Nothing) maybeDefault' maybeComma')
+      : (ParamAttr (Ann trivia' name' trailing') maybeDefault' maybeComma')
       : xs
     ) =
     ParamAttr name maybeDefault (Just (Ann [] comma Nothing))
-      : moveParamsComments (ParamAttr (Ann (trivia ++ trivia') name' Nothing) maybeDefault' maybeComma' : xs)
+      : moveParamsComments (ParamAttr (Ann (trivia ++ trivia') name' trailing') maybeDefault' maybeComma' : xs)
 -- This may seem like a nonsensical case, but keep in mind that blank lines also count as comments (trivia)
 moveParamsComments
   -- , name

--- a/test/diff/regression-218/in.nix
+++ b/test/diff/regression-218/in.nix
@@ -1,0 +1,6 @@
+{
+  foo
+  # bar
+  , baz # qux
+}:
+null

--- a/test/diff/regression-218/out.nix
+++ b/test/diff/regression-218/out.nix
@@ -1,0 +1,6 @@
+{
+  foo,
+  # bar
+  baz, # qux
+}:
+null


### PR DESCRIPTION
Fixes #218

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: