### PR TITLE
Support pipe operators

### DIFF
--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -17,7 +17,7 @@ import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Void (Void)
-import Nixfmt.Lexer (lexeme, pushTrivia, takeTrivia, whole)
+import Nixfmt.Lexer (lexeme, takeTrivia, whole)
 import Nixfmt.Parser.Float (floatParse)
 import Nixfmt.Types (
   Ann (..),
@@ -38,7 +38,6 @@ import Nixfmt.Types (
   StringPart (..),
   Term (..),
   Token (..),
-  Trivium (..),
   Whole (..),
   operators,
   tokenText,
@@ -470,7 +469,7 @@ operator t =
                     TMinus -> ">"
                     TMul -> "/"
                     TDiv -> "/*"
-                    TLess -> "="
+                    TLess -> "=|"
                     TGreater -> "="
                     TNot -> "="
                     _ -> ""

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -424,8 +424,8 @@ data Token
   | TLessEqual
   | TNot
   | TUnequal
-  | TPipeTo
-  | TPipeFrom
+  | TPipeForward
+  | TPipeBackward
   | SOF
   deriving (Eq, Show)
 
@@ -469,8 +469,8 @@ operators =
     [Op InfixL TAnd],
     [Op InfixL TOr],
     [Op InfixL TImplies],
-    [Op InfixL TPipeTo],
-    [Op InfixR TPipeFrom]
+    [Op InfixL TPipeForward],
+    [Op InfixR TPipeBackward]
   ]
 
 tokenText :: Token -> Text
@@ -523,6 +523,6 @@ tokenText TLess = "<"
 tokenText TLessEqual = "<="
 tokenText TNot = "!"
 tokenText TUnequal = "!="
-tokenText TPipeTo = "|>"
-tokenText TPipeFrom = "<|"
+tokenText TPipeForward = "|>"
+tokenText TPipeBackward = "<|"
 tokenText SOF = ""

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -424,6 +424,8 @@ data Token
   | TLessEqual
   | TNot
   | TUnequal
+  | TPipeTo
+  | TPipeFrom
   | SOF
   deriving (Eq, Show)
 
@@ -466,7 +468,9 @@ operators =
     ],
     [Op InfixL TAnd],
     [Op InfixL TOr],
-    [Op InfixL TImplies]
+    [Op InfixL TImplies],
+    [Op InfixL TPipeTo],
+    [Op InfixR TPipeFrom]
   ]
 
 tokenText :: Token -> Text
@@ -519,4 +523,6 @@ tokenText TLess = "<"
 tokenText TLessEqual = "<="
 tokenText TNot = "!"
 tokenText TUnequal = "!="
+tokenText TPipeTo = "|>"
+tokenText TPipeFrom = "<|"
 tokenText SOF = ""

--- a/test/diff/operation/in.nix
+++ b/test/diff/operation/in.nix
@@ -156,4 +156,17 @@
       z = 30;
     }
 )
+
+  # Experimental pipe operators
+  (
+  a // b
+  |> f "very long argument should justify splitting this over multiple lines"
+  |> g { }
+  )
+
+  (
+  g { } <|
+    f "very long argument should justify splitting this over multiple lines" <|
+    a // b
+  )
 ]

--- a/test/diff/operation/out.nix
+++ b/test/diff/operation/out.nix
@@ -273,4 +273,17 @@
         z = 30;
       }
   )
+
+  # Experimental pipe operators
+  (
+    a // b
+    |> f "very long argument should justify splitting this over multiple lines"
+    |> g { }
+  )
+
+  (
+    g { }
+    <| f "very long argument should justify splitting this over multiple lines"
+    <| a // b
+  )
 ]


### PR DESCRIPTION
NixOS/nix#11131 landed :tada:

Let the debates about the proper formatting of these particular operators begin! Should they use the same rules as all other operators? This PR assumes yes, but there's an argument for sticking `<|` at the ends of lines rather than at the beginnings, since it is the final value in a chain of `<|`s that is special. :shrug: