### PR TITLE
[fix] remove space leaks in (,) by using strict state

### DIFF
--- a/src/Nixfmt/Lexer.hs
+++ b/src/Nixfmt/Lexer.hs
@@ -5,7 +5,7 @@
 
 module Nixfmt.Lexer (lexeme, pushTrivia, takeTrivia, whole) where
 
-import Control.Monad.State (MonadState, evalStateT, get, modify, put)
+import Control.Monad.State.Strict (MonadState, evalStateT, get, modify, put)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -44,7 +44,7 @@ module Nixfmt.Types (
   walkSubprograms,
 ) where
 
-import Control.Monad.State (StateT)
+import Control.Monad.State.Strict (StateT)
 import Data.Bifunctor (first)
 import Data.Foldable (toList)
 import Data.Function (on)


### PR DESCRIPTION
- benchmarks on maintainer-list.nix give a baseline of 88M max residency, nice triangle of death and a bit over 4 seconds duration
- heap profile shows a lot of memory allocated to (,)
- removing usagge of (,) in own code didn't affect the profile
- changing to strict state improves memory from 88 to 40 max residency and runtime goes down by 1 second