### PR TITLE
Create `.pre-commit-hooks.yaml`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: &id nixfmt
+  name: *id
+  entry: *id
+  language: haskell
+  types:
+    - nix
+  description: The official (but not yet stable) formatter for Nix code

--- a/README.md
+++ b/README.md
@@ -49,6 +49,49 @@ Haskell dependencies will be built by Cabal.
 * `nixfmt < input.nix` – reads Nix code from `stdin`, formats it, and outputs to `stdout`
 * `nixfmt file.nix` – format the file in place
 
+### With the `pre-commit` tool
+
+If you have Nix files in a Git repo and you want to make sure that they’re formatted with `nixfmt`, then you can use the `pre-commit` tool from [pre-commit.com](https://pre-commit.com):
+
+1. Make sure that you have the `pre-commit` command:
+
+    ```console
+    $ pre-commit --version
+    pre-commit 3.7.1
+    ```
+
+2. Make sure that you’re in your Git repo:
+
+    ```console
+    $ cd <path-to-git-repo>
+    ```
+
+3. Make sure that the `pre-commit` tool is installed as a Git pre-commit hook:
+
+    ```console
+    $ pre-commit install
+    pre-commit installed at .git/hooks/pre-commit
+    ```
+
+4. If you don’t already have one, then create a `.pre-commit-config.yaml` file.
+
+5. Add an entry for the `nixfmt` hook to your `.pre-commit-config.yaml` file:
+
+    ```
+    repos:
+        - repo: https://github.com/NixOS/nixfmt
+          rev: <version>
+          hooks:
+                - id: nixfmt
+    ```
+
+    If you want to use a stable version of `nixfmt`, then replace `<version>` with a tag from this repo. If you want to use an unstable version of `nixfmt`, then replace `<version>` with a commit hash from this repo.
+
+6. Try to commit a badly formatted Nix file in order to make sure that everything works.
+
+> [!WARNING]
+> `nixfmt`’s integration with the `pre-commit` tool is relatively new. At the moment, none of the stable releases of `nixfmt` can be used with the `pre-commit` tool. You’ll have to use an unstable version for the time being.
+
 
 ## About Serokell
 


### PR DESCRIPTION
This will allow people to enforce the style of `.nix` files in their own repos via [the `pre-commit` tool][1]. This change is related to #221, but it doesn’t actually implement the idea proposed in that issue.

[1]: https://pre-commit.com
