### PR TITLE
Deprecate recursive mode

### DIFF
--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -37,6 +37,7 @@ executable nixfmt
     , nixfmt
     , unix             >= 2.7.2 && < 2.9
     , text             >= 1.2.3 && < 2.2
+    , transformers
 
     -- for System.IO.Atomic
     , directory        >= 1.3.3 && < 1.4


### PR DESCRIPTION
The recursive mode has caused problems because it doesn't do any filtering, which can mess with files in `.git` directories and elsewhere. While we could support sane implicit filters and an interface to filter explicitly, that adds complexity and maintenance burden.

Instead, we can promote the use of `treefmt` instead, a "formatting multiplexer", which supports file filtering by default. So `nixfmt` will only be the "backend" formatter, while `treefmt` is the frontend.

Previously discussed in a team meeting here:
https://github.com/NixOS/nixfmt/issues/151#issuecomment-2008026386