### PR TITLE
Run Nixpkgs diff on nixfmt commits merged into the base branch

### DIFF
--- a/scripts/sync-pr.sh
+++ b/scripts/sync-pr.sh
@@ -92,7 +92,7 @@ bodyForCommitIndex() {
     echo -e "base: $subject\n\nFormat using the base commit from nixfmt PR $nixfmtPrNumber: $url"
   else
     url=$nixfmtUrl/pull/$nixfmtPrNumber/commits/$commit
-    echo -e "$index: $subject\n\nFormat using commit number $index from nixfmt PR $nixfmtPrNumber: $url"
+    echo -e "$index: $subject\n\nFormat using commit number $index from nixfmt PR $nixfmtPrNumber: $url (merged into the base branch)"
   fi
 }
 
@@ -249,6 +249,8 @@ update() {
 
   step "Checking out nixfmt at $nixfmtCommit"
   git -C nixfmt checkout -q "$nixfmtCommit"
+  step "Merging with the base commit $nixfmtBaseCommit"
+  git -C nixfmt merge --no-stat --no-edit "$nixfmtBaseCommit"
 }
 
 # Format Nixpkgs with a specific nixfmt version and push the result.


### PR DESCRIPTION
Previously the Nixpkgs diff script would first format the latest base branch commit, before formatting with each of the PRs commits. This however causes problems if the PR commits are on top of a much older commit that has bugs that aren't in the base branch anymore.

More visually, a PR branch graph looks like this:

```mermaid
gitGraph
  commit id:"B"
  branch pr
  checkout pr
  commit id:"P"
  commit id:"Q"
  checkout main
  commit id:"L"
```

Where
- B: Earlier commit on the base branch off of which the PR is branched off (aka merge base)
- L: Latest commit on the base branch, fixes a bug
- P: First commit of the PR, doesn't contain the bug fix
- Q: Second commit of the PR, also doesn't contain the bug fix

Previously CI ran:
- Format with L, with bugfix
- Format with P, without bugfix
- Format with Q, without bugfix

With this change, CI runs:
- Format with L, with bugfix
- Format with (L merged with P), with bugfix
- Format with (L merged with Q), with bugfix

This was discovered in https://github.com/NixOS/nixfmt/pull/209's Nixpkgs diff check, which failed with problems that were already fixed (such as #217 and some idempotency bug): https://github.com/NixOS/nixfmt/actions/runs/10567042446/job/29275137031?pr=209

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: