### PR TITLE
Enable `TypeFamilies` by default

### DIFF
--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.0
 name:                nixfmt
 version:             0.6.0
-synopsis:            Official formatter for Nix code 
+synopsis:            Official formatter for Nix code
 description:
   A formatter for Nix that ensures consistent and clear formatting by forgetting
   almost all existing formatting during parsing.
@@ -65,6 +65,7 @@ library
 
   default-extensions:
     PackageImports
+    TypeFamilies
 
   other-extensions:
     DeriveFoldable


### PR DESCRIPTION
For some reason nixfmt isn't building on my machine and GHC complains about a type equality constraint.