### PR TITLE
Improve sandboxing of `pull_request_target` workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This restricts the action to be no longer able to push content, so it can only comment on PRs or open and close (not merge) them.

This means that even if someone manages to bypass the sandboxing somehow, they can not really exploit this workflow to extract secrets etc.