### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for nixfmt
 
+## 1.1.0 -- 2025-10-07
+
+- Added support for "language annotation" comments (e.g. `/* lang */ ""`), used by things like tree-sitter grammars: <https://github.com/NixOS/nixfmt/pull/343>
+- Fixed a regression causing incorrect path value indentation: <https://github.com/NixOS/nixfmt/pull/342>
+
 ## 1.0.1 -- 2025-09-16
 
 - Fix bug where `--ir` would overwrite the source file: <https://github.com/NixOS/nixfmt/pull/322>

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                nixfmt
-version:             1.0.1
+version:             1.1.0
 synopsis:            Official formatter for Nix code
 description:
   A formatter for Nix that ensures consistent and clear formatting by forgetting


### PR DESCRIPTION
- Added support for "language annotation" comments (e.g. `/* lang */ ""`), used by things like tree-sitter grammars: <https://github.com/NixOS/nixfmt/pull/343>
- Fixed a regression causing incorrect path value indentation: <https://github.com/NixOS/nixfmt/pull/342>


Commits since 1.0.1: https://github.com/NixOS/nixfmt/compare/v1.0.1...master