### PR TITLE
test: add failing idempotency case for trailing comment after multili…

### DIFF
--- a/test/diff/comment/in.nix
+++ b/test/diff/comment/in.nix
@@ -165,4 +165,9 @@
   "
 " # c
   t
+
+  # Trailing comment after multiline string, next item indented differently
+  "
+" # c
+      t2
 ]

--- a/test/diff/comment/out-pure.nix
+++ b/test/diff/comment/out-pure.nix
@@ -164,4 +164,9 @@
 "
   # c
   t
+
+  # Trailing comment after multiline string, next item indented differently
+  "
+" # c
+  t2
 ]

--- a/test/diff/comment/out.nix
+++ b/test/diff/comment/out.nix
@@ -164,4 +164,9 @@
 "
   # c
   t
+
+  # Trailing comment after multiline string, next item indented differently
+  "
+" # c
+  t2
 ]


### PR DESCRIPTION
…ne string

A line comment trailing the closing quote of a multiline "..." string becomes non-idempotent when reformatting moves the next item to the comment's column.
The second pass reattaches the comment as leading.

    [ "
    " # c
          t2
    ]