### PR TITLE
fix: indent arguments of parenthesized function application

### DIFF
--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -476,7 +476,7 @@ prettyApp indentFunction pre hasPost f a =
       absorbApp (Application f' a') = group' Transparent (absorbApp f') <> line <> nest (group' Priority $ absorbInner a')
       -- First argument
       absorbApp expr
-        | indentFunction && null comment' = nest $ group' RegularG $ line' <> pretty expr
+        | indentFunction && null comment' = group' RegularG $ line' <> pretty expr
         | otherwise = pretty expr
 
       -- Render the inner arguments of a function call

--- a/test/diff/apply/in.nix
+++ b/test/diff/apply/in.nix
@@ -314,4 +314,10 @@
   )
 
   (badge "https://github.com/maralorn/haskell-taskwarrior/actions/workflows/haskell.yml/badge.svg" "https://github.com/maralorn/haskell-taskwarrior/actions")
+  # Parenthesized function application should indent args past callee.
+  (
+    (func-builder {
+      bar = "baz";
+    }) arg1 arg2
+  )
 ]

--- a/test/diff/apply/out-pure.nix
+++ b/test/diff/apply/out-pure.nix
@@ -340,4 +340,6 @@
   ) { })
 
   (badge "https://github.com/maralorn/haskell-taskwarrior/actions/workflows/haskell.yml/badge.svg" "https://github.com/maralorn/haskell-taskwarrior/actions")
+  # Parenthesized function application should indent args past callee.
+  ((func-builder { bar = "baz"; }) arg1 arg2)
 ]

--- a/test/diff/apply/out.nix
+++ b/test/diff/apply/out.nix
@@ -357,4 +357,12 @@
   ) { })
 
   (badge "https://github.com/maralorn/haskell-taskwarrior/actions/workflows/haskell.yml/badge.svg" "https://github.com/maralorn/haskell-taskwarrior/actions")
+  # Parenthesized function application should indent args past callee.
+  (
+    (func-builder {
+      bar = "baz";
+    })
+    arg1
+    arg2
+  )
 ]

--- a/test/diff/apply/out.nix
+++ b/test/diff/apply/out.nix
@@ -362,7 +362,7 @@
     (func-builder {
       bar = "baz";
     })
-    arg1
-    arg2
+      arg1
+      arg2
   )
 ]


### PR DESCRIPTION
Previously, `prettyApp` nested the function head as well as its arguments, so both sat at the same level. I believe this was related to fda8afa, which introduced `indentFunction` when nesting was column-based (`nest 2`, measured from a `base` anchor). eb732b1 later made `nest` ordinal and dropped `base`, leaving the head's nest as a duplicate of its caller's.

Both `indentFunction=True` callers already wrap the application in `nest`, so the head's own nest was redundant. Removing it nests arguments one level deeper.

Fixes #385 
