### PR TITLE
ci: publish using Knope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
-name: Release on Version Change
+name: Release
 
 on:
   push:
     branches:
       - master
-    paths:
-      - 'nixfmt.cabal'
+
+# Group workflow runs by ref.
+# New runs cancel any pending run.
+# In-progress runs are allowed to complete.
+concurrency:
+  group: push-${{ github.ref }}
 
 defaults:
   run:
@@ -14,95 +18,187 @@ defaults:
 permissions: {}
 
 jobs:
-  release-if-version-changed:
-    runs-on: ubuntu-latest
+  version:
+    name: Check version
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+
     permissions:
-      # Needed to create the release
-      contents: write
+      contents: read # Needed to checkout content & get published releases
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      published: ${{ steps.check_published.outputs.published }}
+      unpublished: ${{ steps.check_published.outputs.unpublished }}
 
     steps:
-      - name: Checkout main
+      - name: Checkout metadata
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 2  # need previous commit for comparison
           persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: nixfmt.cabal
 
       - name: Get version from nixfmt.cabal
         id: get_version
         run: |
-          CABAL_FILE="nixfmt.cabal"
-
-          # Extract the version
-          VERSION=$(grep -m1 "^version:" $CABAL_FILE | awk '{print $2}')
+          VERSION=$(grep -m1 "^version:" nixfmt.cabal | awk '{print $2}')
           echo "Version found in cabal: $VERSION"
-
-          # Get previous version from last commit
-          PREV_VERSION=$(git show HEAD~1:"$CABAL_FILE" | grep -m1 "^version:" | awk '{print $2}')
-          echo "Previous version: $PREV_VERSION"
-
-          # Export for later steps
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "prev_version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Check if version changed
-        id: compare
+      - name: Check if version is published
+        id: check_published
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const tag = `v${process.env.VERSION}`
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({ ...context.repo, tag })
+              core.notice(`${tag} already published (${data.published_at})`)
+              core.setOutput("published", "true")
+            } catch (err) {
+              if (err.status !== 404) throw err
+              core.notice(`${tag} not published`)
+              core.setOutput("unpublished", "true")
+            }
+
+
+  create-release-pr:
+    name: Create or update release PR
+
+    if: needs.version.outputs.published
+    needs: version
+    runs-on: ubuntu-latest # cachix-action needs a full VM
+    timeout-minutes: 5
+
+    # Match nixfmt-ci app, for testing on forks
+    permissions:
+      contents: write # Needed to push the release PR branch
+      pull-requests: write # Needed to open the release PR
+
+    steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: vars.NIXFMT_CI_APP_CLIENT_ID
+        id: app-token
+        with:
+          client-id: ${{ vars.NIXFMT_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NIXFMT_CI_APP_PRIVATE_KEY }}
+          permission-contents: write # Needed to push the release PR branch
+          permission-pull-requests: write # Needed to open the release PR
+
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Knope needs to find the previous tag and read conventional commits
+          fetch-tags: true
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Get GitHub App User ID
+        id: app-id
+        if: steps.app-token.outputs.app-slug
         env:
-          PREV_VERSION: ${{ steps.get_version.outputs.prev_version }}
-          VERSION: ${{ steps.get_version.outputs.version }}
-        run: |
-          if [ "$PREV_VERSION" != "$VERSION" ]; then
-            echo "version_changed=true" >> "$GITHUB_ENV"
-            echo "::notice ::✅ Version changed from $PREV_VERSION to $VERSION"
-          else
-            echo "version_changed=false" >> "$GITHUB_ENV"
-            echo "::notice ::Version did not change, skipping release"
-          fi
-      - name: Extract changelog section for current version
-        if: ${{ env.version_changed == 'true' }}
+          APP_USERNAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "app-id=$(gh api "/users/$APP_USERNAME" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
         env:
-          VERSION: ${{ steps.get_version.outputs.version }}
+          APP_USER_ID: ${{ steps.app-id.outputs.app-id || '41898282' }}
+          APP_USERNAME: ${{ steps.app-token.outputs.app-slug || 'github-actions' }}[bot]
         run: |
-          echo "Extracting changelog section for version $VERSION"
-
-          # Extract everything after the "## <version>" header until the next "## "
-          awk -v ver="$VERSION" '
-            $0 ~ "^##[[:space:]]+" ver {found=1; next}
-            found && /^##[[:space:]]+/ {exit}
-            found
-          ' CHANGELOG.md > RELEASE_NOTES.md
-
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "::error ::⚠️ No changelog section found for version $VERSION"
-            echo "(Make sure you have a header like '## $VERSION -- YYYY-MM-DD')"
-            echo "- No notes will be attached to the release -"
-            echo "No changelog section found for version $VERSION." > RELEASE_NOTES.md
-            exit 1
-          fi
-
-          echo "---- Extracted Changelog ----"
-          cat RELEASE_NOTES.md
-          echo "--------------------------"
+          git config --global user.name "$APP_USERNAME"
+          git config --global user.email "$APP_USER_ID+$APP_USERNAME@users.noreply.github.com"
 
       - name: Setup Nix
-        if: ${{ env.version_changed == 'true' }}
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
 
       - name: Setup Cachix cache
-        if: ${{ env.version_changed == 'true' }}
         uses: cachix/cachix-action@38b082610b782e7e93e209c35fd730d399dee866 # v17
         with:
           name: nixos-nixfmt
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Install Knope
+        run: |
+          nix-build main.nix -A pkgs.knope
+          realpath result/bin >> "$GITHUB_PATH"
+          echo "Installed $(result/bin/knope --version)"
+          rm result
+
+      - name: Cut release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          git switch -c prepare-release
+          knope prepare-release --verbose
+          echo "version=$(knope print-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Create release PR
+        if: needs.version.outputs.version != steps.release.outputs.version
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          git commit -m "chore: release $VERSION"
+          git push --force --set-upstream origin prepare-release
+          knope create-release-pr --verbose
+
+
+  publish-release:
+    name: Publish ${{ needs.version.outputs.version }}
+
+    if: needs.version.outputs.unpublished
+    needs: version
+    runs-on: ubuntu-latest # use a full VM for building static binary
+    timeout-minutes: 300 # allow for a cache-miss building the static binary
+
+    # Match nixfmt-ci app, for testing on forks
+    permissions:
+      contents: write # Needed to create the release
+
+    steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: vars.NIXFMT_CI_APP_CLIENT_ID
+        id: app-token
+        with:
+          client-id: ${{ vars.NIXFMT_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NIXFMT_CI_APP_PRIVATE_KEY }}
+          permission-contents: write # Needed to create the release
+
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Setup Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+
+      - name: Setup Cachix cache
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: nixos-nixfmt
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Install Knope
+        run: |
+          nix-build main.nix -A pkgs.knope
+          realpath result/bin >> "$GITHUB_PATH"
+          echo "Installed $(result/bin/knope --version)"
+          rm result
+
+      - name: Print version
+        run: echo "::notice::Publishing $(knope print-version)"
 
       - name: Build static binary
-        if: ${{ env.version_changed == 'true' }}
-        run: |
-          nix-build -A packages.nixfmt-static
+        run: nix-build -A packages.nixfmt-static
 
-      - name: Create GitHub Release
-        if: ${{ env.version_changed == 'true' }}
+      - name: Publish release
+        run: knope release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: "${{ steps.get_version.outputs.version }}"
-        run:
-          gh release create "v$VERSION" ./result/bin/nixfmt --title "v$VERSION" --notes-file RELEASE_NOTES.md
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
 
 # Group workflow runs by ref.
 # New runs cancel any pending run.
@@ -26,6 +24,7 @@ jobs:
     permissions:
       contents: read # Needed to checkout content & get published releases
 
+    # Note: outputs are empty on non-release branches
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       published: ${{ steps.check_published.outputs.published }}
@@ -37,9 +36,49 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout-cone-mode: false
-          sparse-checkout: nixfmt.cabal
+          sparse-checkout: |
+            nixfmt.cabal
+            knope.toml
+
+      - name: Get release branch from knope.toml
+        id: get_branch
+        shell: python
+        run: |
+          import os, sys, tomllib
+
+          try:
+              with open("knope.toml", "rb") as f:
+                  config = tomllib.load(f)
+          except FileNotFoundError:
+              sys.exit("::error file=knope.toml::File not found.")
+
+          # Collect CreatePullRequest workflow steps
+          pr_steps = [
+              step
+              for workflow in config.get("workflows", [])
+              for step in workflow.get("steps", [])
+              if step.get("type") == "CreatePullRequest"
+          ]
+
+          if len(pr_steps) != 1:
+              sys.exit("::error file=knope.toml::Expected exactly 1 'CreatePullRequest' step, found {len(pr_steps)}.")
+
+          try:
+              release_branch = pr_steps[0]["base"]
+          except KeyError:
+              sys.exit("::error file=knope.toml::No 'base' key for 'CreatePullRequest' step.")
+
+          current_branch = os.environ["GITHUB_REF_NAME"]
+
+          if release_branch == current_branch:
+              print(f"::notice::Current branch '{current_branch}' is the release branch.", file=sys.stderr)
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  print("is-release-branch=true", file=f)
+          else:
+              print(f"::notice::Current branch '{current_branch}' is not the release branch '{release_branch}'.", file=sys.stderr)
 
       - name: Get version from nixfmt.cabal
+        if: steps.get_branch.outputs.is-release-branch
         id: get_version
         run: |
           VERSION=$(grep -m1 "^version:" nixfmt.cabal | awk '{print $2}')
@@ -48,6 +87,7 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Check if version is published
+        if: steps.get_branch.outputs.is-release-branch
         id: check_published
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -133,7 +173,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
-          git switch -c prepare-release
+          git switch -c "prepare-release/$GITHUB_REF_NAME"
           knope prepare-release --verbose
           echo "version=$(knope print-version)" >> "$GITHUB_OUTPUT"
 
@@ -144,7 +184,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           git commit -m "chore: release $VERSION"
-          git push --force --set-upstream origin prepare-release
+          git push --force --set-upstream origin "prepare-release/$GITHUB_REF_NAME"
           knope create-release-pr --verbose
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for nixfmt
 
-## 1.4.0 -- 2026-07-07
+## 1.4.0 (2026-07-07)
 
 - Added `/*nixfmt:disable*/` and `/*nixfmt:enable*/` comment directives to exclude regions of code from formatting: <https://github.com/NixOS/nixfmt/pull/388>
 - Fixed language annotations being detached from their string when comments are hoisted out of function applications: <https://github.com/NixOS/nixfmt/pull/425>
@@ -9,11 +9,11 @@
   - `nixpkgs` and `treefmt-nix` are now flake inputs that can "follow" downstream flake inputs.
 - Improved the Neovim setup instructions in the README: <https://github.com/NixOS/nixfmt/pull/414>, <https://github.com/NixOS/nixfmt/pull/415>
 
-## 1.3.1 -- 2026-05-31
+## 1.3.1 (2026-05-31)
 - Fixed aarch64-darwin build: <https://github.com/NixOS/nixfmt/pull/409>
 - Added aarch64-linux and aarch64-darwin builds to CI: <https://github.com/NixOS/nixfmt/pull/409>
 
-## 1.3.0 -- 2026-05-26
+## 1.3.0 (2026-05-26)
 - Updated our dependencies: <https://github.com/NixOS/nixfmt/pull/389>
 - Replaced references to `nixfmt-rfc-style` with `nixfmt`: <https://github.com/NixOS/nixfmt/pull/369>, <https://github.com/NixOS/nixfmt/pull/389>
 - Format pipe operator chains on multiple lines: <https://github.com/NixOS/nixfmt/pull/372>
@@ -35,7 +35,7 @@
 
 [nixfmt-rs]: https://github.com/Mic92/nixfmt-rs
 
-## 1.2.0 -- 2026-01-08
+## 1.2.0 (2026-01-08)
 - Reformat indented strings, reformatting to simple strings when appropriate: <https://github.com/NixOS/nixfmt/pull/348>
 - Added musl static build and nixfmt-static package: <https://github.com/NixOS/nixfmt/pull/349>
 - Added auto-release GitHub Actions workflow: <https://github.com/NixOS/nixfmt/pull/354>
@@ -49,17 +49,17 @@
 - Added link to standard.md in README: <https://github.com/NixOS/nixfmt/pull/361>
 - Fixed typo in README for nixfmt installation: <https://github.com/NixOS/nixfmt/pull/345>
 
-## 1.1.0 -- 2025-10-07
+## 1.1.0 (2025-10-07)
 
 - Added support for "language annotation" comments (e.g. `/* lang */ ""`), used by things like tree-sitter grammars: <https://github.com/NixOS/nixfmt/pull/343>
 - Fixed a regression causing incorrect path value indentation: <https://github.com/NixOS/nixfmt/pull/342>
 
-## 1.0.1 -- 2025-09-16
+## 1.0.1 (2025-09-16)
 
 - Fix bug where `--ir` would overwrite the source file: <https://github.com/NixOS/nixfmt/pull/322>
 - Fix `pre-commit` hook so it works without cabal: <https://github.com/NixOS/nixfmt/pull/311>
 
-## 1.0.0 -- 2025-07-09
+## 1.0.0 (2025-07-09)
 
 The [Nix Formatting Team](https://nixos.org/community/teams/formatting/) is happy to present the first stable release of the official Nix formatter! The basis for this milestone is [RFC 166](https://github.com/NixOS/rfcs/pull/166), which defined the [standard for Nix formatting](https://github.com/NixOS/nixfmt/blob/master/standard.md), established the Nix Formatting team and set the groundwork for nixfmt to become the official formatter.
 
@@ -75,7 +75,7 @@ Other than the above, there are some notable UX changes:
   - In stdin-mode, `--filename <path>` can now be used to specify a filename for diagnostics.
   - Number of indentation spaces can now be configured using `--indent <number>`
 
-## 0.6.0 -- 2023-10-31
+## 0.6.0 (2023-10-31)
 
 * Fix escaping of interpolations after dollar signs.
 * Fix nixfmt trying to allocate temp files that aren't used.
@@ -84,7 +84,7 @@ Other than the above, there are some notable UX changes:
 * `nixfmt [dir]` now recursively formats nix files in that directory.
 * Float and int literal parsing now matches nix.
 
-## 0.5.0 -- 2022-03-15
+## 0.5.0 (2022-03-15)
 
 * Add a nix flake to the nixfmt project.
 * Add a --verify flag to check idempotency.
@@ -92,24 +92,24 @@ Other than the above, there are some notable UX changes:
 * Fix escaping of interpolations after single quotes.
 * Fix handling of multiline strings with spaces in the last line.
 
-## 0.4.0 -- 2020-02-10
+## 0.4.0 (2020-02-10)
 
 * Report non-conforming files on the same line to aid line-oriented processing
 * Fix help, summary, and version flag contents.
 * Fix indentation of leading comments in parens
 
-## 0.3.0 -- 2019-08-29
+## 0.3.0 (2019-08-29)
 
 * Added check flag for use in CI.
 * Added quiet flag to disable all output on stderr.
 * Further improved indentation.
 * Fixed bugs where Nix code with different semantics was emitted in some cases.
 
-## 0.2.1 -- 2019-07-29
+## 0.2.1 (2019-07-29)
 
 * Fixed missing linebreaks in set abstractions.
 
-## 0.2.0 -- 2019-07-25
+## 0.2.0 (2019-07-25)
 
 * Fixed indentation of binders and some other expressions.
 * Use atomic writes to avoid data loss.
@@ -118,7 +118,7 @@ Other than the above, there are some notable UX changes:
 * Simplified some code.
 * Many other formatting improvements.
 
-## 0.1.0 -- 2019-05-11
+## 0.1.0 (2019-05-11)
 
 * The first released version of nixfmt. This project aims to provide a
   consistent formatter for Nix code. This release is capable of parsing all of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,50 @@ Releases are managed using [Knope](https://knope.tech), a CLI tool for generatin
 Whenever we have unreleased changes, there should be a release PR showing what the next release will look like.
 To publish the release, just merge the PR and CI will handle the rest.
 
+### Creating an LTS branch
+
+`knope.toml` configures the branch releases will target in the `CreatePullRequest` workflow step.
+CI automation is triggered when the pushed branch matches the `base` branch configured in Knope.
+
+If we need to maintain LTS releases for a version that `master` has diverged from, we must first create an LTS branch:
+
+#### Switch to the older release
+
+```console
+git switch --detach v1.2.3
+```
+
+#### Create an LTS branch
+
+```console
+git switch --create lts/v1.2.x
+```
+
+#### Update `knope.toml`
+
+```diff
+  [[workflows.steps]]
+  type = "CreatePullRequest"
+- base = "master"
++ base = "lts/v1.2.x"
+```
+
+```console
+git add --patch knope.toml
+git commit -m "chore(knope): set base branch to lts/v1.2.x"
+```
+
+#### Push the LTS branch
+
+```console
+git push --set-upstream upstream lts/v1.2.x
+```
+
+#### Usage
+
+CI will now recognise this as a release branch, because the branch name matches the `base` configured in `knope.toml`'s `CreatePullRequest` step.
+Changes merged into the LTS branch will cause a release PR to be created, and releases merged into the LTS branch will be automatically published.
+
 ### Manually preparing a release
 
 If you wish to make a release that differs from the automated release PR, you can create your own release PR.
@@ -182,38 +226,11 @@ gh pr create
 
 We've discussed automatic release PRs and manually creating a release PR, but a release is only published after the release has been merged.
 
-Usually, we merge releases into `master` because they are part of Nixfmt's mainline development.
-Releases merged into `master` are automatically published by CI:
+Releases merged into a release branch are automatically published by CI:
+- `knope.toml` is checked, to see whether `CreatePullRequest`→`base` matches the current branch name.
 - The version is checked, to see whether it has been published already.
 - A static `nixfmt` binary is compiled.
 - A release is published to GitHub Releases, with the static `nixfmt` binary attached.
 
 If CI fails, re-running the release workflow will attempt to publish again.
-Additionally, any push to `master` that has an unpublished version will attempt to create a release, so followup fixes will also attempt to release if the initial release failed.
-
-#### Manually publishing a release
-
-If you need to publish a release manually, you can do so using `knope release`.
-
-Before starting, checkout the commit to be published (typically the `chore: release` commit).
-
-> [!TIP]
-> To release on a branch other than `master`, you must manually edit `knope.toml`:
-> ```diff
->   [[workflows.steps]]
->   type = "CreatePullRequest"
-> - base = "master"
-> + base = "your-branch"
-> ```
->
-> You do not need to commit this change, however you could consider committing it if `your-branch` is a LTS branch that may get further releases.
-
-Build the static binary:
-```console
-nix-build -A packages.nixfmt-static
-```
-
-Publish the release:
-```console
-knope release
-```
+Additionally, any push to a release branch that has an unpublished version will attempt to create a release, so followup fixes will also attempt to release if the initial release failed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,32 @@ However this is not always avoidable and they occasionally need manual adjustmen
 When editing a test or adding a new one, try to put it into a separate commit as to not mix input changes with diff changes.
 Retrospectively fixing this requires advanced git rebasing skills, and using a helper tool like [lazygit](https://github.com/jesseduffield/lazygit) is strongly recommended.
 
+### Documenting changes
+
+User-facing changes should be documented for inclusion in the changelog and release notes, either via [changesets](https://knope.tech/reference/concepts/change-file/) or [conventional commits](https://knope.tech/reference/concepts/conventional-commits/).
+
+> [!IMPORTANT]
+> The actual `CHANGELOG.md` file should not be edited manually, as it is managed by Knope.
+
+To create a "change file" in `.changeset`, you can run:
+```console
+knope document-change
+```
+This will interactively create a change file, prompting for summary and severity.
+
+Alternatively, manually write a markdown file in `.changeset`, declaring the [semver](https://knope.tech/reference/concepts/semantic-versioning/) severity of the change:
+```markdown
+---
+default: minor
+---
+
+# Summary of the change
+
+Optional longer description of the change.
+```
+
+In the frontmatter, you are declaring how this change affects packages managed by Knope, of which we only have one: "default".
+
 ## Debugging
 
 Short strings can easily be tested with `cabal v2-run --verbose=0 nixfmt -- -w=80 < <(echo $'some code here')`.
@@ -88,3 +114,106 @@ We call this process "expanding" groups, and the rendering algorithm will try to
 This frees the Pretty phase of having to think too much about whether or not a piece of code will fit onto the rest of the line.
 
 `layout` in `Predoc.hs` is the entry point of the rendering process, it will do various pre-processing on the IR and then call into `layoutGreedy` which implements the actual algorithm.
+
+## Releasing
+
+Releases are managed using [Knope](https://knope.tech), a CLI tool for generating changelogs and bumping versions using semver, conventional commits, and `.changeset/*.md` files.
+
+Whenever we have unreleased changes, there should be a release PR showing what the next release will look like.
+To publish the release, just merge the PR and CI will handle the rest.
+
+### Manually preparing a release
+
+If you wish to make a release that differs from the automated release PR, you can create your own release PR.
+
+#### Create a release branch
+
+Before starting, switch to a new branch:
+```console
+git switch --create my-custom-release
+```
+
+Alternatively, checkout your new branch in a separate worktree:
+```console
+git worktree add ../my-custom-release
+```
+
+#### Prepare the release
+
+Use Knope to bump the version and write release notes to the changelog:
+```console
+knope prepare-release
+```
+
+> [!TIP]
+> See `knope prepare-release --help` for more options, including pre-release labels and manually specified version numbers.
+
+> [!TIP]
+> If Knope can't identify any changes since the latest tag, `prepare-release` will do nothing.
+>
+> Usually that's what you want, but if you need to prepare an "empty" release you can create a bogus change file in `.changeset`:
+> ```markdown
+> ---
+> default: invalid
+> ---
+> ```
+>
+> `knope prepare-release` will empty `.changeset` anyway, so this file will not be committed.
+
+Optionally, at this point you can manually edit the changelog entry that Knope created.
+
+#### Commit changes
+
+`prepare-release` will have staged its changes, but if you've edited anything you may need to stage your changes (e.g. using `git add --patch`).
+
+Commit the release using:
+```bash
+git commit -m "chore: release $(knope print-version)"
+```
+
+#### Open a Pull Request
+
+Create a Pull Request manually, or using the GitHub CLI:
+```console
+gh pr create
+```
+
+### Publishing a release
+
+We've discussed automatic release PRs and manually creating a release PR, but a release is only published after the release has been merged.
+
+Usually, we merge releases into `master` because they are part of Nixfmt's mainline development.
+Releases merged into `master` are automatically published by CI:
+- The version is checked, to see whether it has been published already.
+- A static `nixfmt` binary is compiled.
+- A release is published to GitHub Releases, with the static `nixfmt` binary attached.
+
+If CI fails, re-running the release workflow will attempt to publish again.
+Additionally, any push to `master` that has an unpublished version will attempt to create a release, so followup fixes will also attempt to release if the initial release failed.
+
+#### Manually publishing a release
+
+If you need to publish a release manually, you can do so using `knope release`.
+
+Before starting, checkout the commit to be published (typically the `chore: release` commit).
+
+> [!TIP]
+> To release on a branch other than `master`, you must manually edit `knope.toml`:
+> ```diff
+>   [[workflows.steps]]
+>   type = "CreatePullRequest"
+> - base = "master"
+> + base = "your-branch"
+> ```
+>
+> You do not need to commit this change, however you could consider committing it if `your-branch` is a LTS branch that may get further releases.
+
+Build the static binary:
+```console
+nix-build -A packages.nixfmt-static
+```
+
+Publish the release:
+```console
+knope release
+```

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,82 @@
+[package]
+changelog = "CHANGELOG.md"
+assets = "result/bin/nixfmt"
+
+[[package.versioned_files]]
+path = "nixfmt.cabal"
+regex = '(?m)^version[ \t]*:[ \t]*(?<version>.+)$'
+
+
+[github]
+owner = "NixOS"
+repo = "nixfmt"
+
+
+[release_notes]
+change_templates = [
+    "### $summary ($commit_hash)\n\n$details\n\nBy $commit_author_name",
+    "- **$summary** by $commit_author_name ($commit_hash)",
+    "### $summary\n\n$details",
+    "- **$summary**",
+]
+extra_changelog_sections = [
+    { types = ["major"], name = "Major changes" },
+    { types = ["minor"], name = "Minor changes" },
+    { types = ["patch"], name = "Patch changes" },
+    { types = ["note"], footers = ["Changelog-Note"], name = "Notes" }
+]
+
+
+[[workflows]]
+name = "prepare-release"
+help_text = "Prepare a new release (bump version & update changelog)"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+allow_empty = true # Fail silently when there's nothing to release
+
+
+[[workflows]]
+name = "create-release-pr"
+help_text = "Create or update a PR for the current release"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "master"
+
+[workflows.steps.title]
+template = "chore: release $version"
+
+[workflows.steps.body]
+template = """
+**This PR was created by Knope. Merging it will release $version.**
+
+---
+
+$changelog
+"""
+
+
+[[workflows]]
+name = "release"
+help_text = "Publish the current release"
+
+[[workflows.steps]]
+type = "Release"
+
+
+[[workflows]]
+name = "document-change"
+help_text = "Create a new change file to be included in the next release"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+
+[[workflows]]
+name = "print-version"
+help_text = "Print the current version of the project"
+
+[[workflows.steps]]
+type = "Command"
+command = "echo '$version'"

--- a/main.nix
+++ b/main.nix
@@ -163,6 +163,7 @@ in
       haskellPackages.haskell-language-server
       shellcheck
       hlint
+      knope
       treefmtEval.config.build.wrapper
     ];
   };


### PR DESCRIPTION
Migrate the changelog and release process to [Knope](https://knope.tech).

This is based on what @mdaniels5757 implemented in [nixpkgs-vet](https://github.com/NixOS/nixpkgs-vet), and what I recently added to [Freecam](https://github.com/MinecraftFreecam/Freecam).

### Architecture

The `release.yml` workflow runs on all pushes.

Its first job, `version`, checks out `nixfmt.cabal` & `knope.toml`:
- Reads `base` from `knope.toml`'s `CreatePullRequest` step to determine if this is a release branch.
- Reads `version:` from `nixfmt.cabal`, similar to the existing workflow.
- Queries GitHub's `getReleaseByTag` to determine whether the current version has already been published to GitHub Releases.
  - Draft releases are ignored, because it only has `contents: read` permissions.

This gives us three release states:
- **Not a release branch:** if `knope.toml`'s `base` is not `GITHUB_REF_NAME`, then this is a feature branch not a release branch.
- **Current version is already published:** prepare the next release by creating or updating the release-preview PR.
- **Current version is unpublished:** publish the release that has been merged to `master`.

#### Create release PR

The `Create release PR` job keeps a release-preview PR up to date, so there should normally always be an open PR showing what the next release will contain.

After checkout and setup, it runs `knope prepare-release` to generate the next version and changelog, then commits those changes as `chore: release 1.4.0` and pushes them to the `prepare-release` branch before creating or updating the PR.

#### Publish release

The `Publish release` job actually publishes a release whose version bump has been merged to `master`. This typically happens after a release PR is merged.

After checkout and setup, it builds the static `nixfmt` artifact and then runs `knope release` to tag the release, create the GitHub Release, and upload the artifact.

An important benefit of this design is that release state is determined from the repository's current version, rather than by comparing the current push against the previous commit. If CI fails, subsequent pushes or workflow re-runs will therefore retry the appropriate release step.

### Testing

I tested the initial impl using basic end-to-end tests were performed on [my fork](https://github.com/MattSturgeon/nixfmt):
* [x] Normal pushes update the release-preview PR
  - https://github.com/MattSturgeon/nixfmt/actions/runs/33775807660
  - https://github.com/MattSturgeon/nixfmt/pull/3
* [x] Merged version bumps are published to GitHub Releases
  - https://github.com/MattSturgeon/nixfmt/actions/runs/33773464608
  - https://github.com/MattSturgeon/nixfmt/releases/tag/v1.4.0

I have not tested subsequent iterations on a fork yet.

### Known limitation: merge commits

The main issue we may encounter with Knope is [knope#1927](https://github.com/knope-dev/knope/issues/1927). This only affects PRs merged using a merge commit where both the PR commits and the merge commit follow conventional commits.

For that issue, we could:
- [ ] Change the [repository settings](https://github.com/NixOS/nixfmt/settings#merge-button-settings) to disable merge commits, or use the default merge commit message instead of the pull request title.
- [ ] Apply @mdaniels5757's [patches](https://github.com/knope-dev/knope/pull/1931) to a `knope` override in `main.nix`, which could then be used in both the devshell and CI.
- [ ] Live with the friction for now and manually remove duplicate changelog entries before release.

There are also several other relevant issues in [Knope's issue tracker](https://github.com/knope-dev/knope/issues), including some that I have reported while working on these migrations.

