### PR TITLE
chore(knope): patch to ignore conventional merge commits; reference PRs when possible

### DIFF
--- a/knope.patch
+++ b/knope.patch
@@ -1,0 +1,16 @@
+diff --git a/crates/knope/src/integrations/git.rs b/crates/knope/src/integrations/git.rs
+index 4bcd0ed..39eb901 100644
+--- a/crates/knope/src/integrations/git.rs
++++ b/crates/knope/src/integrations/git.rs
+@@ -406,6 +406,11 @@ pub(crate) fn get_commit_messages_after_tag(tag: Option<&str>) -> Result<Vec<Com
+     for oid in revwalk.filter_map(Result::ok) {
+         if !commits_to_exclude.contains(&oid) {
+             if let Ok(commit) = repo.find_commit(oid) {
++                // Hack: unconditionally ignore merge commits.
++                // https://github.com/knope-dev/knope/pull/1931 adds an option for this.
++                if commit.parent_count() > 1 {
++                    continue;
++                }
+                 if let Some(message) = commit.message().map(String::from) {
+                     commits.push(Commit {
+                         message,

--- a/knope.toml
+++ b/knope.toml
@@ -14,7 +14,9 @@ repo = "nixfmt"
 
 [release_notes]
 change_templates = [
+    "### $summary (#$pr_number)\n\n$details\n\nBy $commit_author_name",
     "### $summary ($commit_hash)\n\n$details\n\nBy $commit_author_name",
+    "- **$summary** by $commit_author_name (#$pr_number)",
     "- **$summary** by $commit_author_name ($commit_hash)",
     "### $summary\n\n$details",
     "- **$summary**",

--- a/main.nix
+++ b/main.nix
@@ -13,6 +13,17 @@ let
         nixfmt = final.callCabal2nix "nixfmt" haskellSource { };
       };
     };
+
+    knope = prevPkgs.knope.overrideAttrs (
+      finalAttrs: prevAttrs: {
+        patches = prevAttrs.patches or [ ] ++ [
+          # Ignore conventional merge commits.
+          # Based on https://github.com/knope-dev/knope/pull/1931, which adds a
+          # full ignore_conventional_merge_commits option.
+          ./knope.patch
+        ];
+      }
+    );
   };
 
   pkgs = import nixpkgs {


### PR DESCRIPTION
Some optional follow-ups to #457

### chore(knope): reference PRs when possible

Improve the release notes by referencing PRs instead of commits. Typically, PRs hold additional context, such as a description and discussion.

### chore(knope): vendor `ignore_conventional_merge_commits` patch

Avoid Knope creating "duplicate" change entries when merge commits use conventional commits; we can assume that the commits from the PR itself document the changes and the merge commit is likely redundant.

The patched `pkgs.knope` does take a few minutes to build on my machine, however in practice we will benefit from the `nixos-nixfmt` Cachix.

I considered using `fetchpatch` to avoid vendoring the patch, however:
1. The PR is not merged, so the commits could get garbage collected by GitHub.
2. The PR does not apply cleanly to Knope 0.23.0; there is a merge conflict in `git.rs`.

#### Tested locally:

Without these changes, the next release will currently be documented as:
```markdown
## Features

- **support chained presence checks (a ? b ? c)** by Dyego Aurélio (bf52dec)
- **support chained presence checks (a ? b ? c) (#433)** by Matt Sturgeon (c697836)

## Fixes

- **exponential parse time for nested set parameter defaults** by Dyego Aurélio (14c006e)
- **exponential parse time for nested set parameter defaults (#435)** by dyegoaurelio (6a68b45)
- **indent arguments of parenthesized function application** by Ashwin Mathi (4306749)
- **indent arguments of parenthesized function application (#456)** by Jeremy Fleischman (e48bc70)
```

With these changes, it will instead be:
```markdown
### Features

- **support chained presence checks (a ? b ? c)** by Dyego Aurélio (#1234)

### Fixes

- **exponential parse time for nested set parameter defaults** by Dyego Aurélio (#1234)
- **indent arguments of parenthesized function application** by Ashwin Mathi (#1234)
```

<details><summary>Actual local test</summary>
<p>

```console
$ nix-build main.nix -A pkgs.knope
$ result/bin/knope prepare-release --dry-run
Would fetch Pull Request info from GitHub repo NixOS/nixfmt for 3 changes
Would add the following to nixfmt.cabal: version:             1.5.0
Would add the following to CHANGELOG.md:
## 1.5.0 (2026-09-10)

### Features

- **support chained presence checks (a ? b ? c)** by Dyego Aurélio (#1234)

### Fixes

- **exponential parse time for nested set parameter defaults** by Dyego Aurélio (#1234)
- **indent arguments of parenthesized function application** by Ashwin Mathi (#1234)

Would add files to git:
  nixfmt.cabal
  CHANGELOG.md
```

</p>
</details> 
